### PR TITLE
Add roster teams and live player lookup

### DIFF
--- a/app/pages/roster.vue
+++ b/app/pages/roster.vue
@@ -1,53 +1,84 @@
 <script lang="ts" setup>
 import type { TableColumn } from "@nuxt/ui";
+import type {
+  RosterBestRun,
+  RosterPlayer,
+  RosterResponse,
+  RosterTeam,
+} from "../../shared/types/roster";
 
-interface Member {
-  name: string;
-  race: string;
-  class: string;
-  thumbnail_url?: string;
-  mythic_plus_score?: number;
-  mythic_plus_best_runs?: any;
-}
+const { data: rosterData, status } = await useFetch<RosterResponse>(
+  "/api/roster",
+  {
+    server: true,
+  },
+);
 
-const { data: rosterData, status } = await useFetch<any>("/api/roster", {
-  server: true,
-});
+const viewMode = ref<"list" | "teams">("list");
 
 const guild = computed(() => rosterData.value?.guild || null);
-const members = computed<Member[]>(() => rosterData.value?.members || []);
+const players = computed<RosterPlayer[]>(() => rosterData.value?.players || []);
+const teams = computed<RosterTeam[]>(() => rosterData.value?.teams || []);
 const isLoading = computed(() => status.value === "pending");
 
-const sortedMembers = computed(() => {
-  return [...members.value].sort((a, b) => {
-    if (a.mythic_plus_score && b.mythic_plus_score) {
-      return b.mythic_plus_score - a.mythic_plus_score;
+const compareScoresDesc = (left: number | null, right: number | null) => {
+  const leftHasScore = typeof left === "number";
+  const rightHasScore = typeof right === "number";
+
+  if (leftHasScore && rightHasScore) {
+    return right - left;
+  }
+
+  if (leftHasScore) return -1;
+  if (rightHasScore) return 1;
+  return 0;
+};
+
+const getDisplayName = (player: RosterPlayer) => player.label || player.name;
+
+const sortedPlayers = computed(() => {
+  return [...players.value].sort((a, b) => {
+    const scoreOrder = compareScoresDesc(
+      a.mythic_plus_score,
+      b.mythic_plus_score,
+    );
+
+    if (scoreOrder !== 0) {
+      return scoreOrder;
     }
-    return 0;
+
+    return getDisplayName(a).localeCompare(getDisplayName(b));
   });
 });
 
-const hasMembers = computed(() => sortedMembers.value.length > 0);
+const sortedTeams = computed(() => {
+  return [...teams.value].sort((a, b) => {
+    const scoreOrder = compareScoresDesc(a.team_score, b.team_score);
+
+    if (scoreOrder !== 0) {
+      return scoreOrder;
+    }
+
+    return a.name.localeCompare(b.name);
+  });
+});
+
+const hasPlayers = computed(() => sortedPlayers.value.length > 0);
+const hasTeams = computed(() => sortedTeams.value.length > 0);
 
 const raidProgressionArray = computed(() => {
   if (!guild.value?.raid_progression) return [];
-  // return an array of { name: 'Formatted Name', summary: '1/8 M' }
-  const progressions = guild.value.raid_progression;
-  return Object.keys(progressions).map((key) => {
-    // Format name: 'manaforge-omega' -> 'Manaforge Omega'
-    const formattedName = key
+
+  return Object.keys(guild.value.raid_progression).map((key) => ({
+    name: key
       .split("-")
       .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(" ");
-
-    return {
-      name: formattedName,
-      summary: progressions[key].summary,
-    };
-  });
+      .join(" "),
+    summary: guild.value?.raid_progression?.[key]?.summary || "-",
+  }));
 });
 
-const columns: TableColumn<Member>[] = [
+const columns: TableColumn<RosterPlayer>[] = [
   {
     accessorKey: "name",
     header: "Name",
@@ -60,9 +91,8 @@ const columns: TableColumn<Member>[] = [
     accessorKey: "mythic_plus_score",
     header: "M+ Score",
     cell: ({ row }) => {
-      const score = row.getValue("mythic_plus_score") as number;
-      const color = getScoreColor(score);
-      return h("span", { class: color }, score || "-");
+      const score = row.getValue("mythic_plus_score") as number | null;
+      return h("span", { class: getScoreColor(score) }, score ?? "-");
     },
   },
 ];
@@ -86,8 +116,8 @@ const getClassColor = (className: string) => {
   return colors[className] || "text-gray-500 dark:text-stone-400";
 };
 
-const getScoreColor = (score?: number) => {
-  if (!score) return "text-gray-500 dark:text-stone-400";
+const getScoreColor = (score?: number | null) => {
+  if (typeof score !== "number") return "text-gray-500 dark:text-stone-400";
   if (score >= 3000) return "text-orange-500";
   if (score >= 2500) return "text-purple-500";
   if (score >= 1500) return "text-blue-500";
@@ -97,26 +127,32 @@ const getScoreColor = (score?: number) => {
 };
 
 const hasGuruTag = (name: string) => name.toLowerCase().includes("eir");
+const getLookupStatusLabel = (player: RosterPlayer) =>
+  player.lookup_status === "lookup_failed" ? "Lookup failed" : "No score yet";
+const getRunKey = (run: RosterBestRun, index: number) =>
+  run.id ?? `${run.short_name || "run"}-${run.mythic_level || 0}-${index}`;
 </script>
 
 <template>
   <div class="pt-32 pb-12 min-h-screen">
     <UContainer>
       <div
-        class="mb-12 flex flex-col md:flex-row justify-between items-start md:items-end gap-6"
+        class="mb-12 flex flex-col gap-6 md:flex-row md:items-end md:justify-between"
       >
         <div>
           <h1
-            class="text-5xl md:text-6xl font-heading font-black text-white tracking-tight mb-2 drop-shadow-[4px_4px_0_rgba(0,0,0,1)] [-webkit-text-stroke:2px_black] uppercase"
+            class="mb-2 text-5xl font-heading font-black uppercase tracking-tight text-white drop-shadow-[4px_4px_0_rgba(0,0,0,1)] [-webkit-text-stroke:2px_black] md:text-6xl"
           >
             Guild Roster
           </h1>
           <p
-            class="text-xl font-body text-white font-bold bg-black inline-block px-4 py-2 mt-2 -skew-x-6 border-2 border-black shadow-[4px_4px_0px_0px_rgba(216,180,254,1)]"
+            class="mt-2 inline-block border-2 border-black bg-black px-4 py-2 text-xl font-body font-bold text-white shadow-[4px_4px_0px_0px_rgba(216,180,254,1)] -skew-x-6"
           >
-            Exercise in Futility
-            <span class="text-[#d8b4fe] font-black not-italic px-2">|</span>
-            Illidan (US)
+            {{ guild?.name || "Exercise in Futility" }}
+            <span class="px-2 font-black not-italic text-[#d8b4fe]">|</span>
+            {{ guild?.realm || "Illidan" }} ({{
+              (guild?.region || "us").toUpperCase()
+            }})
           </p>
         </div>
 
@@ -130,7 +166,7 @@ const hasGuruTag = (name: string) => name.toLowerCase().includes("eir");
             class="flex min-w-52 flex-1 flex-col items-center rounded-none border-4 border-black bg-secondary px-6 py-4 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition duration-200 hover:-translate-y-1 hover:shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] md:min-w-0 md:flex-none"
           >
             <span
-              class="text-sm font-black text-white uppercase tracking-widest mb-1"
+              class="mb-1 text-sm font-black uppercase tracking-widest text-white"
               >{{ raid.name }}</span
             >
             <span class="text-3xl font-heading font-black text-white">{{
@@ -140,60 +176,103 @@ const hasGuruTag = (name: string) => name.toLowerCase().includes("eir");
         </div>
       </div>
 
+      <div class="mb-6 flex justify-start md:justify-end">
+        <div
+          class="inline-flex border-4 border-black bg-stone-950 p-1 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]"
+        >
+          <button
+            type="button"
+            class="px-5 py-2 font-black uppercase tracking-[0.25em] transition-colors"
+            :class="
+              viewMode === 'list'
+                ? 'bg-secondary text-white'
+                : 'bg-transparent text-stone-300 hover:text-white'
+            "
+            @click="viewMode = 'list'"
+          >
+            List
+          </button>
+          <button
+            type="button"
+            class="px-5 py-2 font-black uppercase tracking-[0.25em] transition-colors"
+            :class="
+              viewMode === 'teams'
+                ? 'bg-secondary text-white'
+                : 'bg-transparent text-stone-300 hover:text-white'
+            "
+            @click="viewMode = 'teams'"
+          >
+            Teams
+          </button>
+        </div>
+      </div>
+
       <div
-        class="bg-stone-900 border-4 border-black shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] rounded-none overflow-hidden mt-8"
+        class="mt-8 overflow-hidden rounded-none border-4 border-black bg-stone-900 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]"
       >
         <div class="p-1">
           <div
             v-if="isLoading"
-            class="py-10 text-center text-white font-black text-xl uppercase tracking-widest"
+            class="py-10 text-center text-xl font-black uppercase tracking-widest text-white"
           >
             Loading roster...
           </div>
 
-          <div v-else-if="!hasMembers" class="py-16 text-center">
+          <div
+            v-else-if="viewMode === 'list' && !hasPlayers"
+            class="py-16 text-center"
+          >
             <p
               class="text-xs font-black uppercase tracking-[0.35em] text-cyan-300"
             >
-              Season Standby
+              Roster Empty
             </p>
             <p class="mt-3 text-lg font-bold text-stone-300">
-              Between seasons — the roster returns when new Raider.IO data is
-              available.
+              Add players to populate this view.
             </p>
           </div>
 
-          <template v-else>
+          <div
+            v-else-if="viewMode === 'teams' && !hasTeams"
+            class="py-16 text-center"
+          >
+            <p
+              class="text-xs font-black uppercase tracking-[0.35em] text-cyan-300"
+            >
+              No Teams Yet
+            </p>
+            <p class="mt-3 text-lg font-bold text-stone-300">
+              Add team definitions to group your roster.
+            </p>
+          </div>
+
+          <template v-else-if="viewMode === 'list'">
             <div class="block md:hidden">
-              <div
-                v-for="member in sortedMembers"
-                :key="member.name"
-                class="p-5"
-              >
+              <div v-for="player in sortedPlayers" :key="player.id" class="p-5">
                 <div class="flex items-start justify-between gap-4">
                   <div>
                     <div class="flex items-center gap-1">
                       <p
-                        class="font-black text-xl text-white uppercase tracking-tight"
+                        class="font-black text-xl uppercase tracking-tight text-white"
                       >
-                        {{ member.name }}
+                        {{ getDisplayName(player) }}
                       </p>
                       <UPopover
-                        v-if="hasGuruTag(member.name)"
+                        v-if="hasGuruTag(player.name)"
                         :ui="{
                           content:
                             'bg-stone-800 border-2 border-black text-white shadow-[4px_4px_0_0_black] ring-0 rounded-none',
                         }"
                       >
                         <button
-                          class="cursor-pointer hover:scale-110 transition-transform flex items-center text-xl relative -top-px"
+                          class="relative -top-px flex cursor-pointer items-center text-xl transition-transform hover:scale-110"
                           title="M+ Guru"
                         >
                           ✨
                         </button>
                         <template #content>
                           <div
-                            class="px-3 py-2 font-black text-sm uppercase tracking-wider"
+                            class="px-3 py-2 text-sm font-black uppercase tracking-wider"
                           >
                             M+ Guru
                           </div>
@@ -203,61 +282,68 @@ const hasGuruTag = (name: string) => name.toLowerCase().includes("eir");
                     <p
                       :class="[
                         'text-xs font-bold uppercase tracking-wider',
-                        getClassColor(member.class),
+                        getClassColor(player.class),
                       ]"
                     >
-                      {{ member.class }}
+                      {{ player.class }}
+                    </p>
+                    <p
+                      v-if="player.lookup_status !== 'ok'"
+                      class="mt-2 text-xs font-black uppercase tracking-widest text-stone-400"
+                    >
+                      {{ getLookupStatusLabel(player) }}
                     </p>
                   </div>
                   <div
                     :class="[
-                      'font-heading font-black text-xl',
-                      getScoreColor(member.mythic_plus_score),
+                      'font-heading text-xl font-black',
+                      getScoreColor(player.mythic_plus_score),
                     ]"
                   >
-                    {{ member.mythic_plus_score || "-" }}
+                    {{ player.mythic_plus_score ?? "-" }}
                   </div>
                 </div>
                 <div class="mt-4">
                   <div
-                    v-if="member.mythic_plus_best_runs"
-                    class="flex flex-row gap-2 items-center"
+                    v-if="player.mythic_plus_best_runs?.length"
+                    class="flex flex-row items-center gap-2"
                   >
                     <div
-                      v-for="run in member.mythic_plus_best_runs"
-                      :key="run.id"
-                      class="flex flex-col items-center relative group"
+                      v-for="(run, index) in player.mythic_plus_best_runs"
+                      :key="getRunKey(run, index)"
+                      class="group relative flex flex-col items-center"
                     >
                       <div class="relative">
                         <img
                           :src="run.background_image_url"
                           alt=""
-                          class="object-cover h-10 w-10 brightness-75 border-2 border-black rounded-none shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] transition-transform group-hover:scale-110"
+                          class="h-10 w-10 rounded-none border-2 border-black object-cover brightness-75 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] transition-transform group-hover:scale-110"
                         />
                         <div
                           class="absolute inset-0 flex items-center justify-center"
                         >
                           <p
-                            class="text-white font-black text-sm drop-shadow-md"
+                            class="text-sm font-black text-white drop-shadow-md"
                           >
                             {{ run.mythic_level }}
                           </p>
                         </div>
                       </div>
                       <p
-                        class="text-white font-black uppercase text-[10px] mt-1"
+                        class="mt-1 text-[10px] font-black uppercase text-white"
                       >
                         {{ run.short_name }}
                       </p>
                     </div>
                   </div>
-                  <span v-else class="text-white/50 font-black">-</span>
+                  <span v-else class="font-black text-white/50">-</span>
                 </div>
               </div>
             </div>
+
             <div class="hidden md:block">
               <UTable
-                :data="sortedMembers"
+                :data="sortedPlayers"
                 :columns="columns"
                 :loading="isLoading"
                 :ui="{
@@ -269,17 +355,17 @@ const hasGuruTag = (name: string) => name.toLowerCase().includes("eir");
                 <template #name-cell="{ row }">
                   <div class="flex items-center gap-4">
                     <UAvatar
-                      :src="row.original.thumbnail_url"
+                      :src="row.original.thumbnail_url || undefined"
                       size="lg"
-                      :alt="`${row.original.name} avatar`"
-                      class="border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] rounded-none"
+                      :alt="`${getDisplayName(row.original)} avatar`"
+                      class="rounded-none border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]"
                     />
                     <div>
                       <div class="flex items-center gap-1">
                         <p
-                          class="font-black text-xl text-white uppercase tracking-tight"
+                          class="font-black text-xl uppercase tracking-tight text-white"
                         >
-                          {{ row.original.name }}
+                          {{ getDisplayName(row.original) }}
                         </p>
                         <UPopover
                           v-if="hasGuruTag(row.original.name)"
@@ -289,14 +375,14 @@ const hasGuruTag = (name: string) => name.toLowerCase().includes("eir");
                           }"
                         >
                           <button
-                            class="cursor-pointer hover:scale-110 transition-transform flex items-center text-xl relative -top-px"
+                            class="relative -top-px flex cursor-pointer items-center text-xl transition-transform hover:scale-110"
                             title="M+ Guru"
                           >
                             ✨
                           </button>
                           <template #content>
                             <div
-                              class="px-3 py-2 font-black text-sm uppercase tracking-wider"
+                              class="px-3 py-2 text-sm font-black uppercase tracking-wider"
                             >
                               M+ Guru
                             </div>
@@ -311,62 +397,177 @@ const hasGuruTag = (name: string) => name.toLowerCase().includes("eir");
                       >
                         {{ row.original.class }}
                       </p>
+                      <p
+                        v-if="row.original.lookup_status !== 'ok'"
+                        class="mt-2 text-xs font-black uppercase tracking-widest text-stone-400"
+                      >
+                        {{ getLookupStatusLabel(row.original) }}
+                      </p>
                     </div>
                   </div>
                 </template>
+
                 <template #mythic_plus_best_runs-cell="{ row }">
                   <div
-                    v-if="row.original.mythic_plus_best_runs"
-                    class="flex flex-row gap-2 items-center"
+                    v-if="row.original.mythic_plus_best_runs?.length"
+                    class="flex flex-row items-center gap-2"
                   >
                     <div
-                      v-for="run in row.original.mythic_plus_best_runs"
-                      :key="run.id"
-                      class="flex flex-col items-center relative group"
+                      v-for="(run, index) in row.original.mythic_plus_best_runs"
+                      :key="getRunKey(run, index)"
+                      class="group relative flex flex-col items-center"
                     >
                       <div class="relative">
                         <img
                           :src="run.background_image_url"
                           alt=""
-                          class="object-cover h-10 w-10 brightness-75 border-2 border-black rounded-none shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] transition-transform group-hover:scale-110"
+                          class="h-10 w-10 rounded-none border-2 border-black object-cover brightness-75 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] transition-transform group-hover:scale-110"
                         />
                         <div
                           class="absolute inset-0 flex items-center justify-center"
                         >
                           <p
-                            class="text-white font-black text-sm drop-shadow-md"
+                            class="text-sm font-black text-white drop-shadow-md"
                           >
                             {{ run.mythic_level }}
                           </p>
                         </div>
                       </div>
                       <p
-                        class="text-white font-black uppercase text-[10px] mt-1"
+                        class="mt-1 text-[10px] font-black uppercase text-white"
                       >
                         {{ run.short_name }}
                       </p>
                     </div>
                   </div>
-                  <span v-else class="text-white/50 font-black">-</span>
+                  <span v-else class="font-black text-white/50">-</span>
                 </template>
+
                 <template #mythic_plus_score-cell="{ row }">
                   <div
                     :class="[
-                      'font-heading font-black text-xl',
-                      getScoreColor(row.getValue('mythic_plus_score')),
+                      'font-heading text-xl font-black',
+                      getScoreColor(
+                        row.getValue('mythic_plus_score') as number | null,
+                      ),
                     ]"
                   >
-                    {{ row.getValue("mythic_plus_score") || "-" }}
+                    {{
+                      (row.getValue("mythic_plus_score") as number | null) ??
+                      "-"
+                    }}
                   </div>
                 </template>
               </UTable>
+            </div>
+          </template>
+
+          <template v-else>
+            <div class="grid gap-6 p-6 md:grid-cols-2">
+              <section
+                v-for="team in sortedTeams"
+                :key="team.id"
+                class="border-4 border-black bg-stone-950 p-5 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]"
+              >
+                <div class="flex items-start justify-between gap-4">
+                  <div>
+                    <p
+                      class="text-xs font-black uppercase tracking-[0.35em] text-cyan-300"
+                    >
+                      Team
+                    </p>
+                    <h2
+                      class="mt-2 text-2xl font-heading font-black uppercase text-white"
+                    >
+                      {{ team.name }}
+                    </h2>
+                    <p
+                      class="mt-2 text-sm font-black uppercase tracking-wider text-stone-400"
+                    >
+                      {{ team.total_member_count }} players,
+                      {{ team.scored_member_count }} scored
+                    </p>
+                  </div>
+                  <div class="text-right">
+                    <p
+                      class="text-xs font-black uppercase tracking-[0.35em] text-stone-400"
+                    >
+                      Avg
+                    </p>
+                    <p
+                      :class="[
+                        'mt-2 font-heading text-4xl font-black',
+                        getScoreColor(team.team_score),
+                      ]"
+                    >
+                      {{ team.team_score ?? "-" }}
+                    </p>
+                  </div>
+                </div>
+
+                <div class="mt-5 space-y-3">
+                  <div
+                    v-for="player in team.members"
+                    :key="`${team.id}-${player.id}`"
+                    class="flex items-center justify-between gap-4 border-2 border-black bg-stone-900 px-4 py-3"
+                  >
+                    <div class="flex min-w-0 items-center gap-3">
+                      <UAvatar
+                        :src="player.thumbnail_url || undefined"
+                        size="md"
+                        :alt="`${getDisplayName(player)} avatar`"
+                        class="rounded-none border-2 border-black"
+                      />
+                      <div class="min-w-0">
+                        <div class="flex items-center gap-1">
+                          <p
+                            class="truncate font-black uppercase tracking-tight text-white"
+                          >
+                            {{ getDisplayName(player) }}
+                          </p>
+                          <span
+                            v-if="hasGuruTag(player.name)"
+                            class="text-sm"
+                            aria-hidden="true"
+                          >
+                            ✨
+                          </span>
+                        </div>
+                        <p
+                          :class="[
+                            'text-xs font-bold uppercase tracking-wider',
+                            getClassColor(player.class),
+                          ]"
+                        >
+                          {{ player.class }}
+                        </p>
+                        <p
+                          v-if="player.lookup_status !== 'ok'"
+                          class="mt-1 text-[10px] font-black uppercase tracking-widest text-stone-400"
+                        >
+                          {{ getLookupStatusLabel(player) }}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div
+                      :class="[
+                        'text-right font-heading text-2xl font-black',
+                        getScoreColor(player.mythic_plus_score),
+                      ]"
+                    >
+                      {{ player.mythic_plus_score ?? "-" }}
+                    </div>
+                  </div>
+                </div>
+              </section>
             </div>
           </template>
         </div>
       </div>
 
       <div
-        class="mt-4 text-right text-gray-400 font-bold font-mono text-sm uppercase tracking-wider"
+        class="mt-4 text-right font-mono text-sm font-bold uppercase tracking-wider text-gray-400"
       >
         Data powered by
         <a

--- a/app/pages/roster.vue
+++ b/app/pages/roster.vue
@@ -63,6 +63,21 @@ const sortedTeams = computed(() => {
   });
 });
 
+const getSortedTeamMembers = (team: RosterTeam) => {
+  return [...team.members].sort((a, b) => {
+    const scoreOrder = compareScoresDesc(
+      a.mythic_plus_score,
+      b.mythic_plus_score,
+    );
+
+    if (scoreOrder !== 0) {
+      return scoreOrder;
+    }
+
+    return getDisplayName(a).localeCompare(getDisplayName(b));
+  });
+};
+
 const hasPlayers = computed(() => sortedPlayers.value.length > 0);
 const hasTeams = computed(() => sortedTeams.value.length > 0);
 
@@ -507,7 +522,7 @@ const getRunKey = (run: RosterBestRun, index: number) =>
 
                 <div class="mt-5 space-y-3">
                   <div
-                    v-for="player in team.members"
+                    v-for="player in getSortedTeamMembers(team)"
                     :key="`${team.id}-${player.id}`"
                     class="flex items-center justify-between gap-4 border-2 border-black bg-stone-900 px-4 py-3"
                   >

--- a/app/pages/roster.vue
+++ b/app/pages/roster.vue
@@ -63,20 +63,25 @@ const sortedTeams = computed(() => {
   });
 });
 
-const getSortedTeamMembers = (team: RosterTeam) => {
-  return [...team.members].sort((a, b) => {
-    const scoreOrder = compareScoresDesc(
-      a.mythic_plus_score,
-      b.mythic_plus_score,
-    );
+const sortedTeamMembersMap = computed<Record<string, RosterPlayer[]>>(() => {
+  return Object.fromEntries(
+    teams.value.map((team) => [
+      team.id,
+      [...team.members].sort((a, b) => {
+        const scoreOrder = compareScoresDesc(
+          a.mythic_plus_score,
+          b.mythic_plus_score,
+        );
 
-    if (scoreOrder !== 0) {
-      return scoreOrder;
-    }
+        if (scoreOrder !== 0) {
+          return scoreOrder;
+        }
 
-    return getDisplayName(a).localeCompare(getDisplayName(b));
-  });
-};
+        return getDisplayName(a).localeCompare(getDisplayName(b));
+      }),
+    ]),
+  );
+});
 
 const hasPlayers = computed(() => sortedPlayers.value.length > 0);
 const hasTeams = computed(() => sortedTeams.value.length > 0);
@@ -122,8 +127,8 @@ const getClassColor = (className: string) => {
     Mage: "text-[#69CCF0]",
     Monk: "text-[#00FF96]",
     Paladin: "text-[#F58CBA]",
-    Priest: "dark:text-[#FFFFFF] text-[#000000]",
-    Rogue: "text-warning dark:text-[#FFF569]",
+    Priest: "text-[#FFFFFF]",
+    Rogue: "text-[#FFF569]",
     Shaman: "text-[#0070DE]",
     Warlock: "text-[#9482C9]",
     Warrior: "text-[#C79C6E]",
@@ -192,34 +197,36 @@ const getRunKey = (run: RosterBestRun, index: number) =>
       </div>
 
       <div class="mb-6 flex justify-start md:justify-end">
-        <div
+        <UFieldGroup
           class="inline-flex border-4 border-black bg-stone-950 p-1 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)]"
         >
-          <button
-            type="button"
-            class="px-5 py-2 font-black uppercase tracking-[0.25em] transition-colors"
+          <UButton
+            label="List"
+            :active="viewMode === 'list'"
+            color="neutral"
+            variant="ghost"
             :class="
               viewMode === 'list'
-                ? 'bg-secondary text-white'
-                : 'bg-transparent text-stone-300 hover:text-white'
+                ? 'rounded-none bg-secondary/90 text-white shadow-[inset_0_-3px_0_0_rgba(255,255,255,0.18)]'
+                : 'rounded-none text-stone-300 hover:text-white'
             "
-            @click="viewMode = 'list'"
-          >
-            List
-          </button>
-          <button
-            type="button"
             class="px-5 py-2 font-black uppercase tracking-[0.25em] transition-colors"
+            @click="viewMode = 'list'"
+          />
+          <UButton
+            label="Teams"
+            :active="viewMode === 'teams'"
+            color="neutral"
+            variant="ghost"
             :class="
               viewMode === 'teams'
-                ? 'bg-secondary text-white'
-                : 'bg-transparent text-stone-300 hover:text-white'
+                ? 'rounded-none bg-secondary/90 text-white shadow-[inset_0_-3px_0_0_rgba(255,255,255,0.18)]'
+                : 'rounded-none text-stone-300 hover:text-white'
             "
+            class="px-5 py-2 font-black uppercase tracking-[0.25em] transition-colors"
             @click="viewMode = 'teams'"
-          >
-            Teams
-          </button>
-        </div>
+          />
+        </UFieldGroup>
       </div>
 
       <div
@@ -522,7 +529,7 @@ const getRunKey = (run: RosterBestRun, index: number) =>
 
                 <div class="mt-5 space-y-3">
                   <div
-                    v-for="player in getSortedTeamMembers(team)"
+                    v-for="player in sortedTeamMembersMap[team.id] || []"
                     :key="`${team.id}-${player.id}`"
                     class="flex items-center justify-between gap-4 border-2 border-black bg-stone-900 px-4 py-3"
                   >

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -13,8 +13,8 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
   compatibilityDate: "2025-02-15",
   routeRules: {
-    // Cache roster page HTML for 10 minutes (SWR at Vercel edge).
-    "/roster": { swr: 600 },
+    // Cache roster page HTML for 5 minutes (SWR at Vercel edge).
+    "/roster": { swr: 300 },
     // API caching is handled in-handler via defineCachedEventHandler
     // so failed revalidations don't leave stale data stuck forever.
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,4 +1,11 @@
-import { apiEndpoint, repositoryName } from "./slicemachine.config.json";
+import slicemachineConfig from "./slicemachine.config.json";
+
+const repositoryName = String(slicemachineConfig.repositoryName);
+const apiEndpoint =
+  "apiEndpoint" in slicemachineConfig &&
+  typeof slicemachineConfig.apiEndpoint === "string"
+    ? slicemachineConfig.apiEndpoint
+    : undefined;
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   modules: ["@nuxt/ui", "@nuxtjs/prismic"],

--- a/server/api/roster.get.ts
+++ b/server/api/roster.get.ts
@@ -1,81 +1,89 @@
+import type {
+  RosterGuild,
+  RosterPlayer,
+  RosterResponse,
+} from "../../shared/types/roster";
+
 export default defineCachedEventHandler(
-  async (event): Promise<{ guild: any; members: any[] }> => {
+  async (): Promise<RosterResponse> => {
     const raiderIoKey = process.env.RAIDER_IO_KEY;
+    const rosterConfig = getRosterConfig();
 
-    // 1. Fetch guild data
-    const guild = await $fetch<any>("https://raider.io/api/v1/guilds/profile", {
-      query: {
-        region: "us",
-        realm: "illidan",
-        name: "exercise in futility",
-        fields: "members,raid_progression:current-tier",
-        ...(raiderIoKey ? { access_key: raiderIoKey } : {}),
-      },
-      timeout: 8_000,
-    });
+    const guild: RosterGuild = {
+      ...rosterConfig.guild,
+    };
 
-    if (!guild?.members) {
-      return { guild, members: [] };
+    try {
+      const guildProfile = await $fetch<any>(
+        "https://raider.io/api/v1/guilds/profile",
+        {
+          query: {
+            region: rosterConfig.guild.region,
+            realm: rosterConfig.guild.realm,
+            name: rosterConfig.guild.name,
+            fields: "raid_progression:current-tier",
+            ...(raiderIoKey ? { access_key: raiderIoKey } : {}),
+          },
+          timeout: 8_000,
+        },
+      );
+
+      if (guildProfile?.raid_progression) {
+        guild.raid_progression = guildProfile.raid_progression;
+      }
+    } catch (error) {
+      console.error("Failed to fetch guild progression", error);
     }
 
-    // 2. Filter members - get only those with rank < 5
-    let filteredMembers = guild.members
-      .filter((m: any) => m.rank < 5)
-      .map((m: any) => ({
-        name: m.character.name,
-        race: m.character.race,
-        class: m.character.class,
-        mythic_plus_score: 0,
-        mythic_plus_best_runs: null,
-        thumbnail_url: null,
-      }));
+    const players = await Promise.all(
+      rosterConfig.players.map(async (playerConfig): Promise<RosterPlayer> => {
+        const player = createBaseRosterPlayer(playerConfig);
 
-    // 3. Fetch all character data in parallel (with per-request timeout)
-    const scorePromises = filteredMembers.map(async (member: any) => {
-      try {
-        const data = await $fetch<any>(
-          "https://raider.io/api/v1/characters/profile",
-          {
-            query: {
-              region: "us",
-              realm: "illidan",
-              name: member.name,
-              fields:
-                "mythic_plus_scores_by_season:current,mythic_plus_best_runs",
-              ...(raiderIoKey ? { access_key: raiderIoKey } : {}),
+        try {
+          const data = await $fetch<any>(
+            "https://raider.io/api/v1/characters/profile",
+            {
+              query: {
+                region: playerConfig.region,
+                realm: playerConfig.realm,
+                name: playerConfig.name,
+                fields:
+                  "class,race,thumbnail_url,mythic_plus_scores_by_season:current,mythic_plus_best_runs",
+                ...(raiderIoKey ? { access_key: raiderIoKey } : {}),
+              },
+              timeout: 5_000,
             },
-            timeout: 5_000,
-          },
-        );
-
-        if (data?.mythic_plus_scores_by_season?.[0]?.scores?.all) {
-          member.mythic_plus_score = Math.round(
-            data.mythic_plus_scores_by_season[0].scores.all,
           );
-          member.mythic_plus_best_runs = data.mythic_plus_best_runs;
-          member.thumbnail_url = data.thumbnail_url;
+
+          const liveScore = data?.mythic_plus_scores_by_season?.[0]?.scores?.all;
+
+          return {
+            ...player,
+            class: data?.class || player.class,
+            race: data?.race || player.race,
+            thumbnail_url: data?.thumbnail_url || null,
+            mythic_plus_score:
+              typeof liveScore === "number" ? Math.round(liveScore) : null,
+            mythic_plus_best_runs: Array.isArray(data?.mythic_plus_best_runs)
+              ? data.mythic_plus_best_runs
+              : null,
+            lookup_status:
+              typeof liveScore === "number" ? "ok" : "missing_score",
+          };
+        } catch (error) {
+          console.error(`Failed to fetch score for ${playerConfig.name}`, error);
+          return player;
         }
-      } catch (e) {
-        console.error(`Failed to fetch score for ${member.name}`, e);
-      }
-    });
-
-    await Promise.allSettled(scorePromises);
-
-    // 4. Filter out members with 0 score
-    const members = filteredMembers.filter(
-      (m: any) => (m.mythic_plus_score || 0) > 0,
+      }),
     );
 
-    return {
+    return createRosterResponse({
       guild,
-      members,
-    };
+      players,
+      teams: rosterConfig.teams,
+    });
   },
   {
-    // Cache for 10 minutes server-side. Unlike SWR route rules on Vercel,
-    // defineCachedEventHandler only caches successful responses — a failed
-    // revalidation won't leave stale data stuck indefinitely.
     maxAge: 600,
     name: "roster",
     getKey: () => "roster",

--- a/server/api/roster.get.ts
+++ b/server/api/roster.get.ts
@@ -4,7 +4,7 @@ import type {
   RosterResponse,
 } from "../../shared/types/roster";
 
-export default defineCachedEventHandler(
+export default defineEventHandler(
   async (): Promise<RosterResponse> => {
     const raiderIoKey = process.env.RAIDER_IO_KEY;
     const rosterConfig = getRosterConfig();
@@ -82,10 +82,5 @@ export default defineCachedEventHandler(
       players,
       teams: rosterConfig.teams,
     });
-  },
-  {
-    maxAge: 600,
-    name: "roster",
-    getKey: () => "roster",
   },
 );

--- a/server/api/roster.get.ts
+++ b/server/api/roster.get.ts
@@ -4,83 +4,80 @@ import type {
   RosterResponse,
 } from "../../shared/types/roster";
 
-export default defineEventHandler(
-  async (): Promise<RosterResponse> => {
-    const raiderIoKey = process.env.RAIDER_IO_KEY;
-    const rosterConfig = getRosterConfig();
+export default defineEventHandler(async (): Promise<RosterResponse> => {
+  const raiderIoKey = process.env.RAIDER_IO_KEY;
+  const rosterConfig = getRosterConfig();
 
-    const guild: RosterGuild = {
-      ...rosterConfig.guild,
-    };
+  const guild: RosterGuild = {
+    ...rosterConfig.guild,
+  };
 
-    try {
-      const guildProfile = await $fetch<any>(
-        "https://raider.io/api/v1/guilds/profile",
-        {
-          query: {
-            region: rosterConfig.guild.region,
-            realm: rosterConfig.guild.realm,
-            name: rosterConfig.guild.name,
-            fields: "raid_progression:current-tier",
-            ...(raiderIoKey ? { access_key: raiderIoKey } : {}),
-          },
-          timeout: 8_000,
+  try {
+    const guildProfile = await $fetch<any>(
+      "https://raider.io/api/v1/guilds/profile",
+      {
+        query: {
+          region: rosterConfig.guild.region,
+          realm: rosterConfig.guild.realm,
+          name: rosterConfig.guild.name,
+          fields: "raid_progression:current-tier",
+          ...(raiderIoKey ? { access_key: raiderIoKey } : {}),
         },
-      );
-
-      if (guildProfile?.raid_progression) {
-        guild.raid_progression = guildProfile.raid_progression;
-      }
-    } catch (error) {
-      console.error("Failed to fetch guild progression", error);
-    }
-
-    const players = await Promise.all(
-      rosterConfig.players.map(async (playerConfig): Promise<RosterPlayer> => {
-        const player = createBaseRosterPlayer(playerConfig);
-
-        try {
-          const data = await $fetch<any>(
-            "https://raider.io/api/v1/characters/profile",
-            {
-              query: {
-                region: playerConfig.region,
-                realm: playerConfig.realm,
-                name: playerConfig.name,
-                fields:
-                  "class,race,thumbnail_url,mythic_plus_scores_by_season:current,mythic_plus_best_runs",
-                ...(raiderIoKey ? { access_key: raiderIoKey } : {}),
-              },
-              timeout: 5_000,
-            },
-          );
-
-          const liveScore = data?.mythic_plus_scores_by_season?.[0]?.scores?.all;
-
-          return {
-            ...player,
-            class: data?.class || player.class,
-            race: data?.race || player.race,
-            thumbnail_url: data?.thumbnail_url || null,
-            mythic_plus_score:
-              typeof liveScore === "number" ? Math.round(liveScore) : null,
-            mythic_plus_best_runs: Array.isArray(data?.mythic_plus_best_runs)
-              ? data.mythic_plus_best_runs
-              : null,
-            lookup_status:
-              typeof liveScore === "number" ? "ok" : "missing_score",
-          };
-        } catch (error) {
-          console.error(`Failed to fetch score for ${playerConfig.name}`, error);
-          return player;
-        }
-      }),
+        timeout: 8_000,
+      },
     );
 
-    return createRosterResponse({
-      guild,
-      players,
-      teams: rosterConfig.teams,
-    });
-  },
-);
+    if (guildProfile?.raid_progression) {
+      guild.raid_progression = guildProfile.raid_progression;
+    }
+  } catch (error) {
+    console.error("Failed to fetch guild progression", error);
+  }
+
+  const players = await Promise.all(
+    rosterConfig.players.map(async (playerConfig): Promise<RosterPlayer> => {
+      const player = createBaseRosterPlayer(playerConfig);
+
+      try {
+        const data = await $fetch<any>(
+          "https://raider.io/api/v1/characters/profile",
+          {
+            query: {
+              region: playerConfig.region,
+              realm: playerConfig.realm,
+              name: playerConfig.name,
+              fields:
+                "class,race,thumbnail_url,mythic_plus_scores_by_season:current,mythic_plus_best_runs",
+              ...(raiderIoKey ? { access_key: raiderIoKey } : {}),
+            },
+            timeout: 5_000,
+          },
+        );
+
+        const liveScore = data?.mythic_plus_scores_by_season?.[0]?.scores?.all;
+
+        return {
+          ...player,
+          class: data?.class || player.class,
+          race: data?.race || player.race,
+          thumbnail_url: data?.thumbnail_url || null,
+          mythic_plus_score:
+            typeof liveScore === "number" ? Math.round(liveScore) : null,
+          mythic_plus_best_runs: Array.isArray(data?.mythic_plus_best_runs)
+            ? data.mythic_plus_best_runs
+            : null,
+          lookup_status: typeof liveScore === "number" ? "ok" : "missing_score",
+        };
+      } catch (error) {
+        console.error(`Failed to fetch score for ${playerConfig.name}`, error);
+        return player;
+      }
+    }),
+  );
+
+  return createRosterResponse({
+    guild,
+    players,
+    teams: rosterConfig.teams,
+  });
+});

--- a/server/assets/roster.json
+++ b/server/assets/roster.json
@@ -10,8 +10,8 @@
       "name": "Nightgrizzly",
       "realm": "illidan",
       "region": "us",
-      "class": "Druid",
-      "race": "Night Elf",
+      "class": "Death Knight",
+      "race": "Blood Elf",
       "label": "Nightgrizzly"
     },
     {
@@ -19,8 +19,8 @@
       "name": "Eiralinn",
       "realm": "illidan",
       "region": "us",
-      "class": "Demon Hunter",
-      "race": "Blood Elf",
+      "class": "Hunter",
+      "race": "Void Elf",
       "label": "Eiralinn"
     },
     {
@@ -47,7 +47,7 @@
       "realm": "illidan",
       "region": "us",
       "class": "Mage",
-      "race": "Blood Elf",
+      "race": "Void Elf",
       "label": "Coffeewizard"
     },
     {
@@ -56,7 +56,7 @@
       "realm": "illidan",
       "region": "us",
       "class": "Druid",
-      "race": "Tauren",
+      "race": "Haranir",
       "label": "Sammfdrood"
     },
     {
@@ -64,8 +64,8 @@
       "name": "Frumplez",
       "realm": "illidan",
       "region": "us",
-      "class": "Demon Hunter",
-      "race": "Blood Elf",
+      "class": "Hunter",
+      "race": "Orc",
       "label": "Frumplez"
     },
     {
@@ -73,8 +73,8 @@
       "name": "Splint",
       "realm": "illidan",
       "region": "us",
-      "class": "Hunter",
-      "race": "Orc",
+      "class": "Warrior",
+      "race": "Human",
       "label": "Splint"
     },
     {
@@ -101,7 +101,7 @@
       "realm": "illidan",
       "region": "us",
       "class": "Demon Hunter",
-      "race": "Blood Elf",
+      "race": "Void Elf",
       "label": "Avoidritz"
     },
     {
@@ -128,7 +128,7 @@
       "realm": "illidan",
       "region": "us",
       "class": "Hunter",
-      "race": "Orc",
+      "race": "Blood Elf",
       "label": "Cynshot"
     },
     {
@@ -137,7 +137,7 @@
       "realm": "illidan",
       "region": "us",
       "class": "Paladin",
-      "race": "Blood Elf",
+      "race": "Dwarf",
       "label": "Tofukittykat"
     },
     {
@@ -145,8 +145,8 @@
       "name": "Zerawin",
       "realm": "illidan",
       "region": "us",
-      "class": "Shaman",
-      "race": "Troll",
+      "class": "Priest",
+      "race": "Night Elf",
       "label": "Zerawin"
     },
     {
@@ -173,46 +173,107 @@
       "realm": "illidan",
       "region": "us",
       "class": "Mage",
-      "race": "Blood Elf",
+      "race": "Goblin",
       "label": "Andstu"
+    },
+    {
+      "id": "qyleth-illidan",
+      "name": "Qyleth",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Rogue",
+      "race": "Blood Elf",
+      "label": "Qyleth"
+    },
+    {
+      "id": "cynzet-illidan",
+      "name": "Cynzet",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Paladin",
+      "race": "Blood Elf",
+      "label": "Cynzet"
+    },
+    {
+      "id": "cantibor-illidan",
+      "name": "Cantibor",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Warlock",
+      "race": "Undead",
+      "label": "Cantibor"
+    },
+    {
+      "id": "lasood-illidan",
+      "name": "Lasood",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Druid",
+      "race": "Kul Tiran",
+      "label": "Lasood"
+    },
+    {
+      "id": "khannot-illidan",
+      "name": "Khannot",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Shaman",
+      "race": "Orc",
+      "label": "Khannot"
+    },
+    {
+      "id": "lysandris-illidan",
+      "name": "Lysandris",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Paladin",
+      "race": "Blood Elf",
+      "label": "Lysandris"
     }
   ],
   "teams": [
     {
-      "id": "push-team-alpha",
-      "name": "Push Team Alpha",
+      "id": "uncle-lharghen",
+      "name": "Uncle Lharghen",
       "memberIds": [
         "nightgrizzly-illidan",
         "eiralinn-illidan",
-        "azkabaar-illidan",
-        "coffeewizard-illidan",
-        "sammfdrood-illidan"
+        "lharghrarn-illidan",
+        "sammfdrood-illidan",
+        "coffeewizard-illidan"
       ]
     },
     {
-      "id": "push-team-beta",
-      "name": "Push Team Beta",
+      "id": "tbd!",
+      "name": "TBD!",
       "memberIds": [
-        "frumplez-illidan",
-        "splint-illidan",
-        "emberwilde-illidan",
-        "rozenthal-illidan",
+        "malitaur-illidan",
+        "lysandris-illidan",
+        "qyleth-illidan",
+        "cantibor-illidan",
         "avoidritz-illidan"
       ]
     },
     {
-      "id": "vault-enjoyers",
-      "name": "Vault Enjoyers",
+      "id": "pumpers",
+      "name": "Pumpers",
       "memberIds": [
+        "khannot-illidan",
         "malitaur-illidan",
-        "halastair-illidan",
-        "cynshot-illidan",
-        "tofukittykat-illidan",
-        "zerawin-illidan",
+        "avoidritz-illidan",
+        "azkabaar-illidan",
+        "rozenthal-illidan"
+      ]
+    },
+    {
+      "id": "campbells-angels",
+      "name": "Campbell's Angels",
+      "memberIds": [
+        "lasood-illidan",
+        "cynzet-illidan",
+        "frumplez-illidan",
         "papsfears-illidan",
-        "ildarani-illidan",
-        "andstu-illidan",
-        "eiralinn-illidan"
+        "coffeewizard-illidan"
       ]
     }
   ]

--- a/server/assets/roster.json
+++ b/server/assets/roster.json
@@ -255,8 +255,8 @@
       ]
     },
     {
-      "id": "pumpers",
-      "name": "Pumpers",
+      "id": "can-our-name-be-coys",
+      "name": "Can Our Name Be Coys?",
       "memberIds": [
         "khannot-illidan",
         "malitaur-illidan",
@@ -274,6 +274,17 @@
         "frumplez-illidan",
         "papsfears-illidan",
         "coffeewizard-illidan"
+      ]
+    },
+    {
+      "id": "silly-geese",
+      "name": "Silly Geese",
+      "memberIds": [
+        "splint-illidan",
+        "halastair-illidan",
+        "cynshot-illidan",
+        "tofukittykat-illidan",
+        "zerawin-illidan"
       ]
     }
   ]

--- a/server/assets/roster.json
+++ b/server/assets/roster.json
@@ -1,0 +1,219 @@
+{
+  "guild": {
+    "name": "Exercise in Futility",
+    "realm": "illidan",
+    "region": "us"
+  },
+  "players": [
+    {
+      "id": "nightgrizzly-illidan",
+      "name": "Nightgrizzly",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Druid",
+      "race": "Night Elf",
+      "label": "Nightgrizzly"
+    },
+    {
+      "id": "eiralinn-illidan",
+      "name": "Eiralinn",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Demon Hunter",
+      "race": "Blood Elf",
+      "label": "Eiralinn"
+    },
+    {
+      "id": "azkabaar-illidan",
+      "name": "Azkabaar",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Warlock",
+      "race": "Orc",
+      "label": "Azkabaar"
+    },
+    {
+      "id": "lharghrarn-illidan",
+      "name": "Lharghrarn",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Warlock",
+      "race": "Orc",
+      "label": "Lharghrarn"
+    },
+    {
+      "id": "coffeewizard-illidan",
+      "name": "Coffeewizard",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Mage",
+      "race": "Blood Elf",
+      "label": "Coffeewizard"
+    },
+    {
+      "id": "sammfdrood-illidan",
+      "name": "Sammfdrood",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Druid",
+      "race": "Tauren",
+      "label": "Sammfdrood"
+    },
+    {
+      "id": "frumplez-illidan",
+      "name": "Frumplez",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Demon Hunter",
+      "race": "Blood Elf",
+      "label": "Frumplez"
+    },
+    {
+      "id": "splint-illidan",
+      "name": "Splint",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Hunter",
+      "race": "Orc",
+      "label": "Splint"
+    },
+    {
+      "id": "emberwilde-illidan",
+      "name": "Emberwilde",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Evoker",
+      "race": "Dracthyr",
+      "label": "Emberwilde"
+    },
+    {
+      "id": "rozenthal-illidan",
+      "name": "Rozenthal",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Evoker",
+      "race": "Dracthyr",
+      "label": "Rozenthal"
+    },
+    {
+      "id": "avoidritz-illidan",
+      "name": "Avoidritz",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Demon Hunter",
+      "race": "Blood Elf",
+      "label": "Avoidritz"
+    },
+    {
+      "id": "malitaur-illidan",
+      "name": "Malitaur",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Druid",
+      "race": "Tauren",
+      "label": "Malitaur"
+    },
+    {
+      "id": "halastair-illidan",
+      "name": "Halastair",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Mage",
+      "race": "Blood Elf",
+      "label": "Halastair"
+    },
+    {
+      "id": "cynshot-illidan",
+      "name": "Cynshot",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Hunter",
+      "race": "Orc",
+      "label": "Cynshot"
+    },
+    {
+      "id": "tofukittykat-illidan",
+      "name": "Tofukittykat",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Paladin",
+      "race": "Blood Elf",
+      "label": "Tofukittykat"
+    },
+    {
+      "id": "zerawin-illidan",
+      "name": "Zerawin",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Shaman",
+      "race": "Troll",
+      "label": "Zerawin"
+    },
+    {
+      "id": "papsfears-illidan",
+      "name": "Papsfears",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Warlock",
+      "race": "Orc",
+      "label": "Papsfears"
+    },
+    {
+      "id": "ildarani-illidan",
+      "name": "Ildarani",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Demon Hunter",
+      "race": "Blood Elf",
+      "label": "Ildarani"
+    },
+    {
+      "id": "andstu-illidan",
+      "name": "Andstu",
+      "realm": "illidan",
+      "region": "us",
+      "class": "Mage",
+      "race": "Blood Elf",
+      "label": "Andstu"
+    }
+  ],
+  "teams": [
+    {
+      "id": "push-team-alpha",
+      "name": "Push Team Alpha",
+      "memberIds": [
+        "nightgrizzly-illidan",
+        "eiralinn-illidan",
+        "azkabaar-illidan",
+        "coffeewizard-illidan",
+        "sammfdrood-illidan"
+      ]
+    },
+    {
+      "id": "push-team-beta",
+      "name": "Push Team Beta",
+      "memberIds": [
+        "frumplez-illidan",
+        "splint-illidan",
+        "emberwilde-illidan",
+        "rozenthal-illidan",
+        "avoidritz-illidan"
+      ]
+    },
+    {
+      "id": "vault-enjoyers",
+      "name": "Vault Enjoyers",
+      "memberIds": [
+        "malitaur-illidan",
+        "halastair-illidan",
+        "cynshot-illidan",
+        "tofukittykat-illidan",
+        "zerawin-illidan",
+        "papsfears-illidan",
+        "ildarani-illidan",
+        "andstu-illidan",
+        "eiralinn-illidan"
+      ]
+    }
+  ]
+}

--- a/server/assets/roster.json
+++ b/server/assets/roster.json
@@ -233,8 +233,8 @@
   ],
   "teams": [
     {
-      "id": "uncle-lharghen",
-      "name": "Uncle Lharghen",
+      "id": "potatoed-patahtoad",
+      "name": "Potatoed Patahtoad",
       "memberIds": [
         "nightgrizzly-illidan",
         "eiralinn-illidan",

--- a/server/utils/roster.ts
+++ b/server/utils/roster.ts
@@ -1,0 +1,162 @@
+import { z } from "zod";
+
+import rosterConfig from "../assets/roster.json";
+import type {
+  RosterGuild,
+  RosterPlayer,
+  RosterResponse,
+  RosterTeam,
+} from "../../shared/types/roster";
+
+const rosterPlayerConfigSchema = z.object({
+  id: z.string().min(1, "Player id is required."),
+  name: z.string().min(1, "Player name is required."),
+  label: z.string().min(1).optional(),
+  region: z.string().min(1, "Player region is required."),
+  realm: z.string().min(1, "Player realm is required."),
+  class: z.string().min(1, "Player class fallback is required."),
+  race: z.string().min(1, "Player race fallback is required."),
+});
+
+const rosterTeamConfigSchema = z.object({
+  id: z.string().min(1, "Team id is required."),
+  name: z.string().min(1, "Team name is required."),
+  memberIds: z.array(z.string().min(1)).default([]),
+});
+
+const rosterConfigSchema = z
+  .object({
+    guild: z.object({
+      name: z.string().min(1, "Guild name is required."),
+      realm: z.string().min(1, "Guild realm is required."),
+      region: z.string().min(1, "Guild region is required."),
+    }),
+    players: z.array(rosterPlayerConfigSchema),
+    teams: z.array(rosterTeamConfigSchema),
+  })
+  .superRefine((config, ctx) => {
+    const playerIds = new Set<string>();
+    const teamIds = new Set<string>();
+
+    config.players.forEach((player, index) => {
+      if (playerIds.has(player.id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["players", index, "id"],
+          message: `Duplicate player id "${player.id}".`,
+        });
+      }
+      playerIds.add(player.id);
+    });
+
+    config.teams.forEach((team, index) => {
+      if (teamIds.has(team.id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["teams", index, "id"],
+          message: `Duplicate team id "${team.id}".`,
+        });
+      }
+      teamIds.add(team.id);
+
+      team.memberIds.forEach((memberId, memberIndex) => {
+        if (!playerIds.has(memberId)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["teams", index, "memberIds", memberIndex],
+            message: `Unknown player id "${memberId}" referenced by team "${team.name}".`,
+          });
+        }
+      });
+    });
+  });
+
+export type RosterConfig = z.infer<typeof rosterConfigSchema>;
+
+const rosterConfigResult = rosterConfigSchema.safeParse(rosterConfig);
+
+const formatRosterConfigError = (issues: z.ZodIssue[]) =>
+  issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "root";
+      return `${path}: ${issue.message}`;
+    })
+    .join("; ");
+
+export function getRosterConfig(): RosterConfig {
+  if (rosterConfigResult.success) {
+    return rosterConfigResult.data;
+  }
+
+  const details = formatRosterConfigError(rosterConfigResult.error.issues);
+  console.error("Invalid roster config:", details);
+
+  throw createError({
+    statusCode: 500,
+    statusMessage: import.meta.dev
+      ? `Invalid roster config: ${details}`
+      : "Invalid roster config.",
+  });
+}
+
+export function createBaseRosterPlayer(
+  player: RosterConfig["players"][number],
+): RosterPlayer {
+  return {
+    id: player.id,
+    name: player.name,
+    label: player.label,
+    region: player.region,
+    realm: player.realm,
+    class: player.class,
+    race: player.race,
+    thumbnail_url: null,
+    mythic_plus_score: null,
+    mythic_plus_best_runs: null,
+    lookup_status: "lookup_failed",
+  };
+}
+
+export function buildRosterTeams(
+  teamConfigs: RosterConfig["teams"],
+  players: RosterPlayer[],
+): RosterTeam[] {
+  const playersById = new Map(players.map((player) => [player.id, player]));
+
+  return teamConfigs.map((team) => {
+    const members = team.memberIds
+      .map((memberId) => playersById.get(memberId))
+      .filter((member): member is RosterPlayer => Boolean(member));
+
+    const scoredMembers = members.filter(
+      (member) => typeof member.mythic_plus_score === "number",
+    );
+    const scoredMemberCount = scoredMembers.length;
+    const totalScore = scoredMembers.reduce(
+      (sum, member) => sum + (member.mythic_plus_score ?? 0),
+      0,
+    );
+
+    return {
+      id: team.id,
+      name: team.name,
+      members,
+      team_score:
+        scoredMemberCount > 0 ? Math.round(totalScore / scoredMemberCount) : null,
+      scored_member_count: scoredMemberCount,
+      total_member_count: members.length,
+    };
+  });
+}
+
+export function createRosterResponse(input: {
+  guild: RosterGuild;
+  players: RosterPlayer[];
+  teams: RosterConfig["teams"];
+}): RosterResponse {
+  return {
+    guild: input.guild,
+    players: input.players,
+    teams: buildRosterTeams(input.teams, input.players),
+  };
+}

--- a/server/utils/roster.ts
+++ b/server/utils/roster.ts
@@ -59,7 +59,19 @@ const rosterConfigSchema = z
       }
       teamIds.add(team.id);
 
+      const seenMemberIds = new Set<string>();
+
       team.memberIds.forEach((memberId, memberIndex) => {
+        if (seenMemberIds.has(memberId)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["teams", index, "memberIds", memberIndex],
+            message: `Duplicate player id "${memberId}" in team "${team.name}".`,
+          });
+        } else {
+          seenMemberIds.add(memberId);
+        }
+
         if (!playerIds.has(memberId)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,

--- a/shared/types/roster.ts
+++ b/shared/types/roster.ts
@@ -1,0 +1,44 @@
+export interface RosterGuild {
+  name: string;
+  realm: string;
+  region: string;
+  raid_progression?: Record<string, { summary: string }>;
+}
+
+export interface RosterBestRun {
+  id?: string | number;
+  short_name?: string;
+  mythic_level?: number;
+  background_image_url?: string;
+}
+
+export type RosterLookupStatus = "ok" | "missing_score" | "lookup_failed";
+
+export interface RosterPlayer {
+  id: string;
+  name: string;
+  label?: string;
+  region: string;
+  realm: string;
+  class: string;
+  race: string;
+  thumbnail_url: string | null;
+  mythic_plus_score: number | null;
+  mythic_plus_best_runs: RosterBestRun[] | null;
+  lookup_status: RosterLookupStatus;
+}
+
+export interface RosterTeam {
+  id: string;
+  name: string;
+  members: RosterPlayer[];
+  team_score: number | null;
+  scored_member_count: number;
+  total_member_count: number;
+}
+
+export interface RosterResponse {
+  guild: RosterGuild;
+  players: RosterPlayer[];
+  teams: RosterTeam[];
+}


### PR DESCRIPTION
## Summary
- Replace the cached roster response with a live server handler that pulls guild progression and per-player Raider.IO data on demand.
- Add a static roster config and shared roster types to support players, teams, and lookup status handling.
- Update the roster page to switch between list and team views, with team cards, scoring, and improved empty states.
- Keep roster display stable when live Raider.IO fields are missing by falling back to configured player data.

## Testing
- Not run
- Verified the diff for roster list rendering, team grouping, and lookup-status fallbacks
- Verified the API response shape now includes `guild`, `players`, and `teams`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Teams view with team cards, aggregated team stats and per-team member lists.
  * Improved roster response including teams and players for richer UI.

* **Improvements**
  * Lookup status indicators now show “Lookup failed” vs “No score yet”.
  * More accurate score display, coloring and sorting (handles missing vs zero scores).
  * Per-team and per-player sorting refined; empty/loading copy updated (e.g., “Roster Empty”, “No Teams Yet”).
* **Chores**
  * Guild header now surfaces guild name, realm and uppercased region.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->